### PR TITLE
Koh blog remove

### DIFF
--- a/TabloidCLI/Repositories/BlogRepository.cs
+++ b/TabloidCLI/Repositories/BlogRepository.cs
@@ -88,7 +88,17 @@ namespace TabloidCLI
 
         public void Delete(int id)
         {
-            throw new NotImplementedException();
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"DELETE FROM Blog WHERE id = @id";
+                    cmd.Parameters.AddWithValue("@id", id);
+
+                    cmd.ExecuteNonQuery();
+                }
+            }
         }
 
         public void InsertTag(Blog blog, Tag tag)

--- a/TabloidCLI/UserInterfaceManagers/BlogManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/BlogManager.cs
@@ -112,6 +112,7 @@ namespace TabloidCLI.UserInterfaceManagers
             Blog blog = new Blog();
 
             Console.Write("Title: ");
+
             blog.Title = Console.ReadLine();
 
             Console.Write("URL: ");
@@ -133,13 +134,13 @@ namespace TabloidCLI.UserInterfaceManagers
             }
 
             Console.WriteLine();
-            Console.Write("New blog title (blank to leave unchanged: ");
+            Console.Write("New blog title (blank to leave unchanged): ");
             string title = Console.ReadLine();
             if (!string.IsNullOrWhiteSpace(title))
             {
                 blogToEdit.Title = title;
             }
-            Console.Write("New URL (blank to leave unchanged: ");
+            Console.Write("New URL (blank to leave unchanged): ");
             string url = Console.ReadLine();
             if (!string.IsNullOrWhiteSpace(url))
             {


### PR DESCRIPTION
## Changes Made
Added missing parens in edit function
Added option to remove previously saved blog posts.

## Testing
git fetch --all
git checkout koh-blog-remove
Run Application
Select Blog Management (Option 2)
Select Edit Blog (Option 4)
Select a blog post to remove.
Check list to be sure the blog was removed.